### PR TITLE
Remove required secret key for tests

### DIFF
--- a/backend/pycon/settings/test.py
+++ b/backend/pycon/settings/test.py
@@ -1,4 +1,4 @@
 from .base import * # noqa
 
 
-SECRET_KEY = env('SECRET_KEY')
+SECRET_KEY = 'this-key-should-only-be-used-for-tests'


### PR DESCRIPTION
I'm doing this to prevent issues when testing PR like in #28

But I think it will fail anyway since we are using secrets[1] for codacy. Maybe we can skip uploading coverage to codacity when testing external PRs. @simobasso ?


[1] Circle CI allows to not pass secrets to forked PRs build, since it is easy for someone to get access to them