### PR TITLE
ci: add codacy token on the build

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -50,4 +50,6 @@ jobs:
             . venv/bin/activate
             cd backend
             python-codacy-coverage -r coverage.xml
+          environment:
+            CODACY_PROJECT_TOKEN: 4d8665c4c7d942ef80ae124883b4ad6d
 


### PR DESCRIPTION
in order to have a coverage on codacy we need to add this token in
the yaml, becouse we can't use the env of circleci. Otherwise, every
env var are open to the world :)